### PR TITLE
[BUGFIX] Replace REQUEST_URI before the typolink

### DIFF
--- a/Classes/Hooks/FileDumpHook.php
+++ b/Classes/Hooks/FileDumpHook.php
@@ -346,17 +346,17 @@ class FileDumpHook implements FileDumpEIDHookInterface
      */
     protected function redirectToUrl($url)
     {
-        if (stripos($url, 't3://') === 0) {
-            $url = $this->resolveUrl($url);
-        }
-
-        $redirect_uri = str_replace(
+        $url = str_replace(
             '###REQUEST_URI###',
             rawurlencode(GeneralUtility::getIndpEnv('REQUEST_URI')),
             $url
         );
+        
+        if (stripos($url, 't3://') === 0) {
+            $url = $this->resolveUrl($url);
+        }
 
-        header('location: ' . $redirect_uri);
+        header('location: ' . $url);
         exit;
     }
 


### PR DESCRIPTION
Else the # get encoded and don't get replaced